### PR TITLE
Fix: attachment markdown files can't be shown

### DIFF
--- a/converters/mark/lib/mark.rb
+++ b/converters/mark/lib/mark.rb
@@ -60,16 +60,27 @@ class Mark < RedmineMorePreviews::Conversion
     
     case format
     when "html"
-      base_url = url_for({
-        :controller    => "repositories",
-        :action        => "raw",
-        :id            => object["object"].project.identifier,
-        :repository_id => object["object"].identifier_param,
-        :rev           => object["rev"],
-        :path          => object["path"],
-        :only_path     => true
-        }
-      )
+      if object["object"].class <= Repository
+        base_url = url_for({
+          :controller    => "repositories",
+          :action        => "raw",
+          :id            => object["object"].project.identifier,
+          :repository_id => object["object"].identifier_param,
+          :rev           => object["rev"],
+          :path          => object["path"],
+          :only_path     => true
+          }
+        )
+      else
+        base_url = url_for({
+          :controller    => "attachments",
+          :action        => "show",
+          :id            => object["object"].id,
+          :filename      => object["object"].filename,
+          :only_path     => true
+          }
+        )
+      end
       base = "<base href='#{base_url}'>"
       "#{PANDOC_BIN} #{shell_quote source} -f #{frompts} -t html -s -V header-includes=#{shell_quote base} -o #{outfile}"
       

--- a/converters/mark/lib/mark.rb
+++ b/converters/mark/lib/mark.rb
@@ -71,7 +71,7 @@ class Mark < RedmineMorePreviews::Conversion
           :only_path     => true
           }
         )
-      else
+      elif object["object"].class <= Attachment
         base_url = url_for({
           :controller    => "attachments",
           :action        => "show",


### PR DESCRIPTION
In project's `File` tab, markdown files can't be shown. Error message in `log/production.log`:

```
Started GET "/attachments/more_preview/42/index.html" for 172.17.0.1 at 2022-04-13 09:42:55 +0800
Processing by AttachmentsController#more_preview as HTML
  Parameters: {"id"=>"42"}
  Current user: admin (id=1)
An error occured while generating preview for /xxx/yyy/zzz.md
Exception was: undefined method `identifier_param' for #<Attachment:0x000055fa43276008>
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activemodel-5.2.4.5/lib/active_model/attribute_methods.rb:430:in `method_missing'
/home/redmine/redmine/plugins/redmine_more_previews/converters/mark/lib/mark.rb:67:in `pandoc'
/home/redmine/redmine/plugins/redmine_more_previews/converters/mark/lib/mark.rb:50:in `convert'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/conversion.rb:188:in `block in transient_preview'
/usr/share/rvm/rubies/ruby-2.6.6/lib/ruby/2.6.0/tmpdir.rb:93:in `mktmpdir'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/conversion.rb:181:in `transient_preview'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/conversion.rb:203:in `cached_preview'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/conversion.rb:167:in `block in preview'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/conversion.rb:132:in `synchronize'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/conversion.rb:132:in `sync'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/conversion.rb:167:in `preview'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/converter.rb:332:in `convert'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/patches/attachment_patch.rb:40:in `more_preview'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/patches/attachments_controller_patch.rb:95:in `send_more_preview'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/patches/attachments_controller_patch.rb:63:in `block (2 levels) in more_preview'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_controller/metal/mime_responds.rb:203:in `respond_to'
/home/redmine/redmine/plugins/redmine_more_previews/lib/redmine_more_previews/patches/attachments_controller_patch.rb:62:in `more_preview'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/abstract_controller/base.rb:194:in `process_action'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_controller/metal/rendering.rb:30:in `process_action'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.5/lib/active_support/callbacks.rb:109:in `block in run_callbacks'
/home/redmine/redmine/lib/redmine/sudo_mode.rb:65:in `sudo_mode'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.5/lib/active_support/callbacks.rb:118:in `block in run_callbacks'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.5/lib/active_support/callbacks.rb:136:in `run_callbacks'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/abstract_controller/callbacks.rb:41:in `process_action'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_controller/metal/rescue.rb:22:in `process_action'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.5/lib/active_support/notifications.rb:168:in `block in instrument'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.5/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.5/lib/active_support/notifications.rb:168:in `instrument'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_controller/metal/instrumentation.rb:32:in `process_action'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_controller/metal/params_wrapper.rb:256:in `process_action'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activerecord-5.2.4.5/lib/active_record/railties/controller_runtime.rb:24:in `process_action'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/abstract_controller/base.rb:134:in `process'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.5/lib/action_view/rendering.rb:32:in `process'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_controller/metal.rb:191:in `dispatch'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_controller/metal.rb:252:in `dispatch'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/routing/route_set.rb:52:in `dispatch'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/routing/route_set.rb:34:in `serve'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/journey/router.rb:52:in `block in serve'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/journey/router.rb:35:in `each'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/journey/router.rb:35:in `serve'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/routing/route_set.rb:840:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-openid-1.4.2/lib/rack/openid.rb:98:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/tempfile_reaper.rb:15:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/etag.rb:27:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/conditional_get.rb:27:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/head.rb:12:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/http/content_security_policy.rb:18:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:266:in `context'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:260:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/middleware/cookies.rb:670:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.5/lib/active_support/callbacks.rb:98:in `run_callbacks'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/middleware/callbacks.rb:26:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/middleware/debug_exceptions.rb:61:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/railties-5.2.4.5/lib/rails/rack/logger.rb:38:in `call_app'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/railties-5.2.4.5/lib/rails/rack/logger.rb:26:in `block in call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.5/lib/active_support/tagged_logging.rb:71:in `block in tagged'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.5/lib/active_support/tagged_logging.rb:28:in `tagged'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.5/lib/active_support/tagged_logging.rb:71:in `tagged'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/railties-5.2.4.5/lib/rails/rack/logger.rb:26:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/request_store-1.4.1/lib/request_store/middleware.rb:19:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/middleware/request_id.rb:27:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/runtime.rb:22:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.5/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/middleware/executor.rb:14:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.5/lib/action_dispatch/middleware/static.rb:127:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/content_length.rb:17:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/rack-cors-1.1.1/lib/rack/cors.rb:100:in `call'
/home/redmine/redmine/vendor/bundle/ruby/2.6.0/gems/railties-5.2.4.5/lib/rails/engine.rb:524:in `call'
/usr/share/rvm/gems/ruby-2.6.6/gems/passenger-6.0.12/src/ruby_supportlib/phusion_passenger/rack/thread_handler_extension.rb:107:in `process_request'
/usr/share/rvm/gems/ruby-2.6.6/gems/passenger-6.0.12/src/ruby_supportlib/phusion_passenger/request_handler/thread_handler.rb:149:in `accept_and_process_next_request'
/usr/share/rvm/gems/ruby-2.6.6/gems/passenger-6.0.12/src/ruby_supportlib/phusion_passenger/request_handler/thread_handler.rb:110:in `main_loop'
/usr/share/rvm/gems/ruby-2.6.6/gems/passenger-6.0.12/src/ruby_supportlib/phusion_passenger/request_handler.rb:419:in `block (3 levels) in start_threads'
/usr/share/rvm/gems/ruby-2.6.6/gems/passenger-6.0.12/src/ruby_supportlib/phusion_passenger/utils.rb:113:in `block in create_thread_and_abort_on_exception'
  Rendering text template
  Rendered text template (0.0ms)
Sent data index.html (0.9ms)
Completed 200 OK in 56ms (Views: 0.6ms | ActiveRecord: 6.7ms)
```