### PR TITLE
Fixing translation for pandoc

### DIFF
--- a/converters/mark/config/locales/pt.yml
+++ b/converters/mark/config/locales/pt.yml
@@ -20,7 +20,7 @@
 #
 
 pt:
-  text_pandoc_available:         "LibreOffice disponível"
+  text_pandoc_available:         "Pandoc disponível"
   redmine_more_previews:
     mark:
       text_explanation:          "Pré-visualização de ficheiros de markdown com Pandoc"


### PR DESCRIPTION
Portuguese translation was incorrect because it should be reading PANDOC instead of LIBREOFFICE